### PR TITLE
feature: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# GitHub Workflows and Actions code review
+/.github/ gregsienkiewicz


### PR DESCRIPTION
Add [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners) to force peer review of changes to `.github` for all workflows and actions.