### PR TITLE
fix: Remove AWS credentials

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -15,9 +15,6 @@ terraform {
 provider "aws" {
   region = "us-east-1"
 
-  access_key = "AKIASJRLZOCXRUOMMD7E"
-  secret_key = "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"
-
   default_tags {
     tags = {
       github = "reimagined-broccoli"


### PR DESCRIPTION
Remove AWS credentials hard-coded in the Terraform AWS provider block.