### PR TITLE
fix (issue 15): Remove security gruop ingress rule allow all tcp/3000

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -136,14 +136,6 @@ resource "aws_security_group" "ecs" {
     security_groups = [aws_security_group.lb.id]
   }
 
-  ingress {
-    description = "Allow ALB inbound traffic"
-    from_port   = 3000
-    to_port     = 3000
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   egress {
     description = "Allow all Egress"
     from_port   = 0


### PR DESCRIPTION
[fix: code scanning alert - Security Groups - Unrestricted Specific Ports - Prevalent known internal port (TCP,3000) #15](https://github.com/gregsienkiewicz/reimagined-broccoli/issues/15)